### PR TITLE
Add `StateMachineBuilder` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,11 @@
 //! from given string ("next") and then, it produces outputs.
 //!
 //! ```rust
-//! use statemachine_rs::machine::{builder::StateMachineBuilder, StateMachine};
+//! use statemachine_rs::machine::{
+//!     builder::BasicStateMachineBuilder, builder::StateMachineBuilder, StateMachine,
+//! };
 //!
-//! let sm = StateMachineBuilder::start()
+//! let sm = BasicStateMachineBuilder::start()
 //!     .initial_state(1)
 //!     .transition(|state, input| match (state, input) {
 //!         (1, "next") => 2,
@@ -35,7 +37,9 @@
 //! The following example describes if you press the button, the state turns to be `On`. Otherwise, `Off`.
 //!
 //! ```rust
-//! use statemachine_rs::machine::{builder::StateMachineBuilder, StateMachine};
+//! use statemachine_rs::machine::{
+//!     builder::BasicStateMachineBuilder, builder::StateMachineBuilder, StateMachine,
+//! };
 //!
 //! #[derive(Clone, Debug, PartialEq)]
 //! enum ButtonState {
@@ -47,7 +51,7 @@
 //!     Press,
 //! }
 //!
-//! let sm = StateMachineBuilder::start()
+//! let sm = BasicStateMachineBuilder::start()
 //!     .initial_state(ButtonState::Off)
 //!     .transition(|state, input| match (state, input) {
 //!         (ButtonState::On, Input::Press) => ButtonState::Off,

--- a/src/machine/builder.rs
+++ b/src/machine/builder.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, marker::PhantomData};
 
 use super::{error::StateMachineError, BasicStateMachine, StateMachine, StateWrapper};
 
-pub trait IStateMachineBuilder<State, Input, Transition, Output>
+pub trait IStateMachineBuilder<State, Input, Transition>
 where
     Transition: Fn(&State, Input) -> State,
     State: Clone,

--- a/src/machine/builder.rs
+++ b/src/machine/builder.rs
@@ -9,10 +9,19 @@ where
 {
     type Output;
 
+    /// Starts the builder.
     fn start() -> Self;
+
+    /// Sets particular initial state to the state machine.
     fn initial_state(self, state: State) -> Self;
+
+    /// Sets particular state to the current state.
     fn current_state(self, state: State) -> Self;
+
+    /// Sets particular transition algorithm to the state machine.
     fn transition(self, next: Transition) -> Self;
+
+    /// To finish the builder. If it fails, returns [`crate::machine::error::StateMachineError`].
     fn build(self) -> Result<Self::Output, Box<dyn std::error::Error>>;
 }
 
@@ -37,30 +46,25 @@ where
 {
     type Output = BasicStateMachine<State, Input, Transition>;
 
-    /// Starts the builder.
     fn start() -> Self {
         Self::default()
     }
 
-    /// Sets particular initial state to the state machine.
     fn initial_state(mut self, state: State) -> Self {
         self.initial_state = Some(state);
         self
     }
 
-    /// Sets particular state to the current state.
     fn current_state(mut self, state: State) -> Self {
         self.current_state = Some(state);
         self
     }
 
-    /// Sets particular transition algorithm to the state machine.
     fn transition(mut self, next: Transition) -> Self {
         self.transition = Some(next);
         self
     }
 
-    /// To finish the builder. If it fails, returns [`crate::machine::error::StateMachineError`].
     fn build(self) -> Result<Self::Output, Box<dyn std::error::Error>> {
         match (self.initial_state, self.transition) {
             (Some(initial_state), Some(transition)) => Ok(BasicStateMachine {

--- a/src/machine/builder.rs
+++ b/src/machine/builder.rs
@@ -2,6 +2,20 @@ use std::{cell::RefCell, marker::PhantomData};
 
 use super::{error::StateMachineError, BasicStateMachine, StateMachine, StateWrapper};
 
+pub trait IStateMachineBuilder<State, Input, Transition, Output>
+where
+    Transition: Fn(&State, Input) -> State,
+    State: Clone,
+{
+    type Output;
+
+    fn start() -> Self;
+    fn initial_state(self, state: State) -> Self;
+    fn current_state(self, state: State) -> Self;
+    fn transition(self, next: Transition) -> Self;
+    fn build(self) -> Result<Self::Output, Box<dyn std::error::Error>>;
+}
+
 /// This builder enables us to assemble StateMachine
 /// (like [`crate::machine::BasicStateMachine`]) more easily.
 pub struct StateMachineBuilder<State, Input, Transition>

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -13,7 +13,9 @@ pub trait StateMachine<State, Input> {
     ///
     /// # Example
     /// ```
-    /// use statemachine_rs::machine::{builder::StateMachineBuilder, StateMachine};
+    /// use statemachine_rs::machine::{
+    ///     builder::BasicStateMachineBuilder, builder::StateMachineBuilder, StateMachine,
+    /// };
     ///
     /// #[derive(Clone, Debug, PartialEq)]
     /// enum ButtonState {
@@ -26,7 +28,7 @@ pub trait StateMachine<State, Input> {
     ///     Press,
     /// }
     ///
-    /// let sm = StateMachineBuilder::start()
+    /// let sm = BasicStateMachineBuilder::start()
     ///     .initial_state(ButtonState::Off)
     ///     .transition(|state, input| match (state, input) {
     ///         (ButtonState::On, Input::Press) => ButtonState::Off,
@@ -43,7 +45,9 @@ pub trait StateMachine<State, Input> {
     ///
     /// # Example
     /// ```
-    /// use statemachine_rs::machine::{builder::StateMachineBuilder, StateMachine};
+    /// use statemachine_rs::machine::{
+    ///     builder::BasicStateMachineBuilder, builder::StateMachineBuilder, StateMachine,
+    /// };
     ///
     /// #[derive(Clone, Debug, PartialEq)]
     /// enum ButtonState {
@@ -55,7 +59,7 @@ pub trait StateMachine<State, Input> {
     ///     Press,
     /// }
     ///
-    /// let sm = StateMachineBuilder::start()
+    /// let sm = BasicStateMachineBuilder::start()
     ///     .initial_state(ButtonState::Off)
     ///     .transition(|state, input| match (state, input) {
     ///         (ButtonState::On, Input::Press) => ButtonState::Off,
@@ -73,7 +77,9 @@ pub trait StateMachine<State, Input> {
     ///
     /// # Example
     /// ```
-    /// use statemachine_rs::machine::{builder::StateMachineBuilder, StateMachine};
+    /// use statemachine_rs::machine::{
+    ///     builder::BasicStateMachineBuilder, builder::StateMachineBuilder, StateMachine,
+    /// };
     ///
     /// #[derive(Clone, Debug, PartialEq)]
     /// enum ButtonState {
@@ -85,7 +91,7 @@ pub trait StateMachine<State, Input> {
     ///     Press,
     /// }
     ///
-    /// let sm = StateMachineBuilder::start()
+    /// let sm = BasicStateMachineBuilder::start()
     ///     .initial_state(ButtonState::Off)
     ///     .transition(|state, input| match (state, input) {
     ///         (ButtonState::On, Input::Press) => ButtonState::Off,
@@ -103,7 +109,9 @@ pub trait StateMachine<State, Input> {
     ///
     /// # Example
     /// ```
-    /// use statemachine_rs::machine::{builder::StateMachineBuilder, StateMachine};
+    /// use statemachine_rs::machine::{
+    ///     builder::BasicStateMachineBuilder, builder::StateMachineBuilder, StateMachine,
+    /// };
     ///
     /// #[derive(Clone, Debug, PartialEq)]
     /// enum ButtonState {
@@ -115,7 +123,7 @@ pub trait StateMachine<State, Input> {
     ///     Press,
     /// }
     ///
-    /// let sm = StateMachineBuilder::start()
+    /// let sm = BasicStateMachineBuilder::start()
     ///     .initial_state(ButtonState::Off)
     ///     .transition(|state, input| match (state, input) {
     ///         (ButtonState::On, Input::Press) => ButtonState::Off,
@@ -133,7 +141,9 @@ pub trait StateMachine<State, Input> {
     ///
     /// # Example
     /// ```
-    /// use statemachine_rs::machine::{builder::StateMachineBuilder, StateMachine};
+    /// use statemachine_rs::machine::{
+    ///     builder::BasicStateMachineBuilder, builder::StateMachineBuilder, StateMachine,
+    /// };
     ///
     /// #[derive(Clone, Debug, PartialEq)]
     /// enum ButtonState {
@@ -146,7 +156,7 @@ pub trait StateMachine<State, Input> {
     ///     Press,
     /// }
     ///
-    /// let sm = StateMachineBuilder::start()
+    /// let sm = BasicStateMachineBuilder::start()
     ///     .initial_state(ButtonState::Off)
     ///     .transition(|state, input| match (state, input) {
     ///         (ButtonState::On, Input::Press) => ButtonState::Off,


### PR DESCRIPTION
## Motivation
Now we don't have any way to expand our own `StateMachineBuilder` because the builder is `struct`. There is no correct way to expand its builder according to the user's own implementation when the users create their own `StateMachine` and want to expand the builder to be able to assemble their `StateMachine`.

## Todo
-[x] Add `StateMachineBuilder` trait.
    - due to [this issue](https://github.com/rust-lang/rust/issues/35203), I can no longer use `mut self` in the functions, so I'll change it to `self`.
-[x] Rename old `StateMachineBuilder` to `BasicMachineBuilder` (because the builder is to create `BasicStateMachine`).
-[x] Update docs.